### PR TITLE
Fixing django-markup/models.py 

### DIFF
--- a/djangomarkup/models.py
+++ b/djangomarkup/models.py
@@ -52,7 +52,7 @@ class TextProcessor(models.Model):
     def convert(self, src_txt):
         function = self.get_function()
         try:
-            return function(src_txt)
+            return unicode(function(src_txt))
         except Exception, err:
             raise ProcessorError(err)
 


### PR DESCRIPTION
FIX - added conversion to unicode in django-markup/models.py. It was causing error UnicodeWithAttrs" in ella/polls-contest.

You see that error raised in this specific situation:
"When you add new contest via newman and you click on change question than click on change answer to the question and save."

Radek
